### PR TITLE
Refactory: Makes nestesd context improper start inherits from Rubocop::Cop::Rspec::Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
 - Add RoboCop::Cop::Vicenzo::RSpec::NestedSubjectRedefinition #2;
 - Add RuboCop::Cop::Vicenzo::Rails::EnumInclusionOfValidation #3;
 - Add RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart #4;
+
+- Change RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart inherits from Rspec::Base #5;

--- a/spec/rubocop/cop/vicenzo/rspec/nested_context_improper_start_spec.rb
+++ b/spec/rubocop/cop/vicenzo/rspec/nested_context_improper_start_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart, :rspec_
       expect_offense(<<~RUBY)
         context 'when the product is for sale' do
           context 'when the color pink is not available' do
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nested `context` should start with `and`, `but`, or `however`, not `when`, `with`, or `without`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nested `context` should start with `and`, `but`, or `however`, not `when`, `with`, or `without`.
             it 'does not show the pink option'
           end
         end
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart, :rspec_
       expect_offense(<<~RUBY)
         context 'when the product is for sale' do
           context 'with the color pink unavailable' do
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nested `context` should start with `and`, `but`, or `however`, not `when`, `with`, or `without`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nested `context` should start with `and`, `but`, or `however`, not `when`, `with`, or `without`.
             it 'does not show the pink option'
           end
         end
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart, :rspec_
       expect_offense(<<~RUBY)
         context 'when the product is for sale' do
           context 'without the color pink available' do
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nested `context` should start with `and`, `but`, or `however`, not `when`, `with`, or `without`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nested `context` should start with `and`, `but`, or `however`, not `when`, `with`, or `without`.
             it 'does not show the pink option'
           end
         end


### PR DESCRIPTION
By Mistake I've built this cop from wrong base