### PR TITLE
Add mixed example and groups in same rspec indentation level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,6 @@
 - Add RoboCop::Cop::Vicenzo::RSpec::NestedSubjectRedefinition #2;
 - Add RuboCop::Cop::Vicenzo::Rails::EnumInclusionOfValidation #3;
 - Add RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart #4;
-- Add RuboCop::Cop::Vicenzo::RSpec::MixedExampleGroups;
+- Add RuboCop::Cop::Vicenzo::RSpec::MixedExampleGroups #6;
 
 - Change RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart inherits from Rspec::Base #5;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@
 - Add RoboCop::Cop::Vicenzo::RSpec::NestedSubjectRedefinition #2;
 - Add RuboCop::Cop::Vicenzo::Rails::EnumInclusionOfValidation #3;
 - Add RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart #4;
+- Add RuboCop::Cop::Vicenzo::RSpec::MixedExampleGroups;
 
 - Change RuboCop::Cop::Vicenzo::RSpec::NestedContextImproperStart inherits from Rspec::Base #5;

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,11 @@
+Vicenzo/RSpec/MixedExampleGroups:
+  Description: 'Check if there are example and groups at same level'
+  Enabled: warning
+  VersionAdded: '0.1.0'
+
 Vicenzo/RSpec/NestedContextImproperStart:
   Description: 'Check if the nested context does not start as a root one.'
-  Enabled: pending
+  Enabled: warning
   VersionAdded: '0.1.0'
 
 Vicenzo/RSpec/NestedLetRedefinition:

--- a/lib/rubocop/cop/vicenzo/rspec/mixed_example_groups.rb
+++ b/lib/rubocop/cop/vicenzo/rspec/mixed_example_groups.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Vicenzo
+      module RSpec
+        # Ensures that examples (`it`, `specify`, `example`)
+        # are not mixed with groups (`describe`, `context`) at the same level.
+        #
+        # @example
+        #   # bad
+        #   RSpec.describe User do
+        #     it { is_expected.to validate_presence_of(:name) }
+        #     describe '#admin?' do
+        #       it { expect(true).to eq(true) }
+        #     end
+        #   end
+        #
+        #   # bad
+        #   RSpec.describe User do
+        #     describe '#admin?' do
+        #       it { expect(true).to eq(true) }
+        #       context 'when email starts with' do
+        #       end
+        #     end
+        #   end
+        #
+        #   # good
+        #   RSpec.describe User do
+        #     describe '#admin?' do
+        #       context 'when email starts with' do
+        #         it { expect(true).to eq(true) }
+        #       end
+        #     end
+        #   end
+        class MixedExampleGroups < RuboCop::Cop::RSpec::Base
+          MSG = 'Do not mix examples (`it`, `specify`, `example`) with groups (`describe`, `context`) ' \
+                'at the same level.'
+
+          def on_block(node)
+            return unless example_or_group?(node)
+
+            parent = node.parent
+            return unless parent
+
+            children = parent.children.select { |child| example_or_group?(child) }
+            example_nodes, group_nodes = children.partition { |n| example?(n) }
+
+            return if example_nodes.empty? || group_nodes.empty?
+
+            add_offense(node)
+          end
+
+          alias on_numblock on_block
+
+          private
+
+          def example_or_group?(node)
+            example?(node) || example_group?(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/vicenzo_cops.rb
+++ b/lib/rubocop/cop/vicenzo_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'vicenzo/rspec/mixed_example_groups'
 require_relative 'vicenzo/rspec/nested_context_improper_start'
 require_relative 'vicenzo/rspec/nested_let_redefinition'
 require_relative 'vicenzo/rspec/nested_subject_redefinition'

--- a/spec/rubocop/cop/vicenzo/rspec/mixed_example_groups_spec.rb
+++ b/spec/rubocop/cop/vicenzo/rspec/mixed_example_groups_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Vicenzo::RSpec::MixedExampleGroups, :rspec_config do
+  context 'when an example and a group exist at the same level' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        RSpec.describe User do
+          it { is_expected.to validate_presence_of(:name) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not mix examples (`it`, `specify`, `example`) with groups (`describe`, `context`) at the same level.
+          describe '#admin?' do
+          ^^^^^^^^^^^^^^^^^^^^^ Do not mix examples (`it`, `specify`, `example`) with groups (`describe`, `context`) at the same level.
+            it { expect(true).to eq(true) }
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a nested example and group exist at the same level' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        RSpec.describe User do
+          describe '#admin?' do
+            it { expect(true).to eq(true) }
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not mix examples (`it`, `specify`, `example`) with groups (`describe`, `context`) at the same level.
+            context 'when email starts with' do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not mix examples (`it`, `specify`, `example`) with groups (`describe`, `context`) at the same level.
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when only examples exist' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe User do
+          it { is_expected.to validate_presence_of(:name) }
+          it { expect(true).to eq(true) }
+        end
+      RUBY
+    end
+  end
+
+  context 'when all examples are not mixed with groups' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe User do
+          describe '#admin?' do
+            context 'when email starts with' do
+              it { expect(true).to eq(true) }
+            end
+
+            context 'when email ends with' do
+              it { expect(true).to eq(true) }
+            end
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This help us avoid mix examples and context and describes together making confusing reading and a good use of lets and subjects