### PR TITLE
Adjust Cops config and Fix enum in array format without options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Add Rightly enable all cops #7;
+- Fix RuboCop::Cop::Vicenzo::Rails::EnumInclusionOfValidation working with array format and no options #7;
+
 ## [0.1.0] - 2025-04-02
 
 - Initial release;

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,11 +1,19 @@
+Vicenzo/Rails/EnumInclusionOfValidation:
+  Description: 'Check if the enum has the inclusion of validation defined.'
+  Enabled: true
+  Severity: convention
+  VersionAdded: '0.1.0'
+
 Vicenzo/RSpec/MixedExampleGroups:
   Description: 'Check if there are example and groups at same level'
-  Enabled: warning
+  Enabled: true
+  Severity: warning
   VersionAdded: '0.1.0'
 
 Vicenzo/RSpec/NestedContextImproperStart:
   Description: 'Check if the nested context does not start as a root one.'
-  Enabled: warning
+  Enabled: true
+  Severity: convention
   VersionAdded: '0.1.0'
 
 Vicenzo/RSpec/NestedLetRedefinition:
@@ -16,10 +24,6 @@ Vicenzo/RSpec/NestedLetRedefinition:
 
 Vicenzo/RSpec/NestedSubjectRedefinition:
   Description: 'Check if a subject is redefined in a nested example group.'
-  Enabled: warning
-  VersionAdded: '0.1.0'
-
-Vicenzo/Rails/EnumInclusionOfValidation:
-  Description: 'Check if the enum has the inclusion of validation defined.'
-  Enabled: convention
+  Enabled: true
+  Severity: warning
   VersionAdded: '0.1.0'

--- a/lib/rubocop/cop/vicenzo/rails/enum_inclusion_of_validation.rb
+++ b/lib/rubocop/cop/vicenzo/rails/enum_inclusion_of_validation.rb
@@ -52,7 +52,7 @@ module RuboCop
           private
 
           def find_validate_option(enum_node)
-            enum_node.last_argument.each_pair.find { |pair| pair.key.value == :validate }
+            options_node_for(enum_node)&.each_pair&.find { |pair| pair.key.value == :validate }
           end
 
           def valid_validate_option?(validate_kwarg)
@@ -62,14 +62,15 @@ module RuboCop
               end
           end
 
-          def last_hash_node(enum_node)
+          def options_node_for(enum_node)
             enum_node.last_argument if enum_node.last_argument.hash_type?
           end
 
           def register_offence_for(enum_node, validate_kwarg)
             if validate_kwarg.nil?
               add_offense(enum_node, message: MSG_MISSING_VALIDATE) do |corrector|
-                corrector.insert_after(last_hash_node(enum_node), ', validate: { allow_nil: true }')
+                last_node = options_node_for(enum_node) || enum_node.last_argument
+                corrector.insert_after(last_node, ', validate: { allow_nil: true }')
               end
             elsif !valid_validate_option?(validate_kwarg)
               add_offense(validate_kwarg, message: MSG_INVALID_VALIDATE) do |corrector|

--- a/rubocop-vicenzo.gemspec
+++ b/rubocop-vicenzo.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email = ['bruno@alumni.usp.br']
 
   spec.summary = 'Cops of Bruno Vicenzo'
-  spec.description = 'Cops with good pratices I have been learning'
+  spec.description = "A growing set of custom RuboCop cops capturing the best practices I've been learning."
   spec.homepage = 'https://github.com/bvicenzo/rubocop-vicenzo'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.1.0'

--- a/spec/rubocop/cop/vicenzo/rails/enum_inclusion_of_validation_spec.rb
+++ b/spec/rubocop/cop/vicenzo/rails/enum_inclusion_of_validation_spec.rb
@@ -10,6 +10,57 @@ RSpec.describe RuboCop::Cop::Vicenzo::Rails::EnumInclusionOfValidation, :config 
       end
     end
 
+    context 'when enum is array format' do
+      context 'and no option is provided' do
+        it 'detects suggests correction' do
+          expect_offense(<<~RUBY)
+            enum :status, [:active, :inactive]
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add `validate: { allow_nil: true }` to the enum.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :status, [:active, :inactive], validate: { allow_nil: true }
+          RUBY
+        end
+      end
+
+      context 'and validate option is missing' do
+        it 'detects suggests correction' do
+          expect_offense(<<~RUBY)
+            enum :status, [:active, :inactive], suffix: true
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add `validate: { allow_nil: true }` to the enum.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            enum :status, [:active, :inactive], suffix: true, validate: { allow_nil: true }
+          RUBY
+        end
+      end
+
+      context 'and there is validate option' do
+        context 'but the allow_nil option is missing' do
+          it 'detects and corrects it' do
+            expect_offense(<<~RUBY)
+              enum :status, %i[active inactive], validate: true, suffix: true
+                                                 ^^^^^^^^^^^^^^ The `validate` option for the enum must be `validate: { allow_nil: true }`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              enum :status, %i[active inactive], validate: { allow_nil: true }, suffix: true
+            RUBY
+          end
+        end
+
+        context 'and allow_nil option is informed' do
+          it 'does not register an offense' do
+            expect_no_offenses(<<~RUBY)
+              enum :status, [:active, :inactive], validate: { allow_nil: true }, suffix: true
+            RUBY
+          end
+        end
+      end
+    end
+
     context 'when validate option is missing' do
       it 'detects suggests correction' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
- Improve gem description;
- Configure all cops to be enabled rightly
- Ensure EnumInclusionOfValidation to works with array format without options