### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.1.1] - 2025-08-12
+
 - Add Rightly enable all cops #7;
 - Fix RuboCop::Cop::Vicenzo::Rails::EnumInclusionOfValidation working with array format and no options #7;
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vicenzo (0.1.0)
+    rubocop-vicenzo (0.1.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.2)
       rubocop-rspec (>= 3.5.0)

--- a/lib/rubocop/vicenzo/version.rb
+++ b/lib/rubocop/vicenzo/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vicenzo
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
## [0.1.1] - 2025-08-12

- Add Rightly enable all cops #7;
- Fix RuboCop::Cop::Vicenzo::Rails::EnumInclusionOfValidation working with array format and no options #7;