### PR TITLE
Change version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.2.0] - 2025-11-27
+
 - Remove RuboCop::Cop::Vicenzo::RSpec::MixedExampleGroups in favor of InconsistentSiblingStructure #10;
 
 - Add RoboCop::Cop::Vicenzo::RSpec::LeakyDefinition #9;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vicenzo (0.1.1)
+    rubocop-vicenzo (0.2.0)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.2)
       rubocop-rspec (>= 3.5.0)

--- a/lib/rubocop/vicenzo/version.rb
+++ b/lib/rubocop/vicenzo/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vicenzo
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
## [0.2.0] - 2025-11-27

- Remove RuboCop::Cop::Vicenzo::RSpec::MixedExampleGroups in favor of InconsistentSiblingStructure #10;

- Add RoboCop::Cop::Vicenzo::RSpec::LeakyDefinition #9;
- Add RoboCop::Cop::Vicenzo::RSpec::InconsistentSiblingStructure #10;

- Fix NestedContextImproperStart to deal with all nested contexts #10;
- Fix NestedLetRedefinition to not point sibling lets as nested #10;
- Fix NestedSubjectRedefinition to not point sibling lets as nested #10;
