### PR TITLE
feat(Vicenzo/Style/MultilineMethodCallParentheses): add AllowedMethods configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add RuboCop::Cop::Vicenzo::Layout::MultilineMethodCallLineBreaks #12;
 - Add RuboCop::Cop::Vicenzo::Style::MultilineMethodCallParentheses #13;
+- Add `AllowedMethods` configuration to `Vicenzo/Style/MultilineMethodCallParentheses` to allow excluding specific methods (e.g., RSpec DSLs like `to` and `change`) from the rule.
 
 ## [0.2.0] - 2025-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add RuboCop::Cop::Vicenzo::Layout::MultilineMethodCallLineBreaks #12;
 - Add RuboCop::Cop::Vicenzo::Style::MultilineMethodCallParentheses #13;
-- Add `AllowedMethods` configuration to `Vicenzo/Style/MultilineMethodCallParentheses` to allow excluding specific methods (e.g., RSpec DSLs like `to` and `change`) from the rule.
+- Add `AllowedMethods` configuration to `Vicenzo/Style/MultilineMethodCallParentheses` to allow excluding specific methods (e.g., RSpec DSLs like `to` and `change`) from the rule #15;
 
 ## [0.2.0] - 2025-11-27
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -49,4 +49,5 @@ Vicenzo/RSpec/LeakyDefinition:
 Vicenzo/Style/MultilineMethodCallParentheses:
   Description: 'Enforces parentheses for method calls with arguments that span multiple lines.'
   Enabled: true
+  AllowedMethods: []
   VersionAdded: '<<next>>'

--- a/lib/rubocop/cop/vicenzo/style/multiline_method_call_parentheses.rb
+++ b/lib/rubocop/cop/vicenzo/style/multiline_method_call_parentheses.rb
@@ -7,20 +7,28 @@ module RuboCop
         # Enforces parentheses for method calls with arguments that span multiple lines.
         # Single-line calls are ignored (parentheses are optional).
         #
+        # This cop accepts an `AllowedMethods` configuration to exempt specific methods
+        # from this rule. This is particularly useful for Fluent DSLs (like RSpec's
+        # `to`, `change`, etc.) where parentheses might hurt readability or conflict
+        # with layout rules.
+        #
         # @example
         #   # bad
         #   method_name arg1,
         #               arg2
         #
         #   # good
-        #   method_name(
-        #     arg1,
-        #     arg2
-        #   )
+        #   method_name(arg1,
+        #               arg2)
         #
-        #   # good (single line - optional)
+        #   # good (single line is always allowed)
         #   method_name arg1, arg2
-        #   method_name(arg1, arg2)
+        #
+        # @example AllowedMethods: ['to']
+        #   # good (allowed by configuration)
+        #   expect { action }.to change {
+        #     model.attribute
+        #   }
         #
         class MultilineMethodCallParentheses < Base
           extend RuboCop::Cop::AutoCorrector

--- a/lib/rubocop/cop/vicenzo/style/multiline_method_call_parentheses.rb
+++ b/lib/rubocop/cop/vicenzo/style/multiline_method_call_parentheses.rb
@@ -38,22 +38,24 @@ module RuboCop
           def check_node(node)
             return unless node.arguments?
             return unless node.multiline?
-            return if node.parenthesized?
-
-            return if node.operator_method? || node.setter_method?
+            return if node.parenthesized? || node.operator_method? || node.setter_method? || allowed_method?(node)
 
             add_offense(node) do |corrector|
               autocorrect(corrector, node)
             end
           end
 
+          def allowed_method?(node)
+            allowed_methods.include?(node.method_name.to_s)
+          end
+
+          def allowed_methods
+            cop_config.fetch('AllowedMethods', [])
+          end
+
           def autocorrect(corrector, node)
             if node.loc.selector
-              gap_range = range_between(
-                node.loc.selector.end_pos,
-                node.first_argument.source_range.begin_pos
-              )
-
+              gap_range = range_between(node.loc.selector.end_pos, node.first_argument.source_range.begin_pos)
               corrector.replace(gap_range, '(')
             else
               corrector.insert_before(node.first_argument, '(')

--- a/spec/rubocop/cop/vicenzo/style/multiline_method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/vicenzo/style/multiline_method_call_parentheses_spec.rb
@@ -1,77 +1,117 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Vicenzo::Style::MultilineMethodCallParentheses, :config do
-  context 'when the code violates style guidelines' do
-    context 'and the call is multiline with arguments' do
-      it 'registers an offense when parentheses are missing' do
-        expect_offense(<<~RUBY)
-          method_name arg1,
-          ^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments that span multiple lines.
-                      arg2
-        RUBY
+  context 'when AllowedMethods configuration not is set' do
+    context 'and the code violates style guidelines' do
+      context 'and the call is multiline with arguments' do
+        it 'registers an offense when parentheses are missing' do
+          expect_offense(<<~RUBY)
+            method_name arg1,
+            ^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments that span multiple lines.
+                        arg2
+          RUBY
 
-        expect_correction(<<~RUBY)
-          method_name(arg1,
-                      arg2)
-        RUBY
+          expect_correction(<<~RUBY)
+            method_name(arg1,
+                        arg2)
+          RUBY
+        end
+      end
+    end
+
+    context 'when the code follows style guidelines' do
+      context 'and the call is single-line' do
+        context 'and parentheses are omitted' do
+          it 'does not register offense (optional style)' do
+            expect_no_offenses(<<~RUBY)
+              method_name arg1, arg2
+            RUBY
+          end
+        end
+
+        context 'and parentheses are present' do
+          it 'does not register offense' do
+            expect_no_offenses(<<~RUBY)
+              method_name(arg1, arg2)
+            RUBY
+          end
+        end
+      end
+
+      context 'and the call is multiline with parentheses' do
+        it 'does not register offense' do
+          expect_no_offenses(<<~RUBY)
+            method_name(
+              arg1,
+              arg2
+            )
+          RUBY
+        end
+      end
+
+      context 'but the method is an operator' do
+        it 'does not register offense for arithmetic operators' do
+          expect_no_offenses(<<~RUBY)
+            sum = 1 +
+                  2
+          RUBY
+        end
+
+        it 'does not register offense for array access' do
+          expect_no_offenses(<<~RUBY)
+            items[
+              index
+            ]
+          RUBY
+        end
+      end
+
+      context 'but the method is a setter' do
+        it 'does not register offense for assignment methods' do
+          expect_no_offenses(<<~RUBY)
+            self.value =
+              10
+          RUBY
+        end
       end
     end
   end
 
-  context 'when the code follows style guidelines' do
-    context 'and the call is single-line' do
-      context 'and parentheses are omitted' do
-        it 'does not register offense (optional style)' do
-          expect_no_offenses(<<~RUBY)
-            method_name arg1, arg2
-          RUBY
-        end
-      end
-
-      context 'and parentheses are present' do
-        it 'does not register offense' do
-          expect_no_offenses(<<~RUBY)
-            method_name(arg1, arg2)
-          RUBY
-        end
-      end
+  context 'when AllowedMethods configuration is set' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Vicenzo/Style/MultilineMethodCallParentheses' => {
+          'AllowedMethods' => %w[allowed_method to]
+        }
+      )
     end
 
-    context 'and the call is multiline with parentheses' do
-      it 'does not register offense' do
-        expect_no_offenses(<<~RUBY)
-          method_name(
-            arg1,
-            arg2
-          )
-        RUBY
-      end
+    it 'does not register an offense for a listed method spanning multiple lines' do
+      expect_no_offenses(<<~RUBY)
+        receiver.allowed_method arg1,
+                                arg2
+      RUBY
     end
 
-    context 'but the method is an operator' do
-      it 'does not register offense for arithmetic operators' do
-        expect_no_offenses(<<~RUBY)
-          sum = 1 +
-                2
-        RUBY
-      end
-
-      it 'does not register offense for array access' do
-        expect_no_offenses(<<~RUBY)
-          items[
-            index
-          ]
-        RUBY
-      end
+    it 'does not register an offense for RSpec DSL (e.g., .to) without parentheses' do
+      expect_no_offenses(<<~RUBY)
+        expect(obj).to change {
+          something
+        }
+      RUBY
     end
 
-    context 'but the method is a setter' do
-      it 'does not register offense for assignment methods' do
-        expect_no_offenses(<<~RUBY)
-          self.value =
-            10
-        RUBY
-      end
+    it 'registers an offense for a method NOT in the allowed list' do
+      expect_offense(<<~RUBY)
+        regular_method arg1,
+        ^^^^^^^^^^^^^^^^^^^^ Use parentheses for method calls with arguments that span multiple lines.
+                       arg2
+      RUBY
+
+      expect_correction(<<~RUBY)
+        regular_method(arg1,
+                       arg2)
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/vicenzo/style/multiline_method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/vicenzo/style/multiline_method_call_parentheses_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Vicenzo::Style::MultilineMethodCallParentheses, :co
       end
     end
 
-    context 'when the code follows style guidelines' do
+    context 'and the code follows style guidelines' do
       context 'and the call is single-line' do
         context 'and parentheses are omitted' do
           it 'does not register offense (optional style)' do


### PR DESCRIPTION
## Context

Currently, the `Vicenzo/Style/MultilineMethodCallParentheses` cop enforces mandatory parentheses for **all** method calls that span multiple lines.

However, this strict rule conflicts with fluent DSLs, particularly in RSpec. For example, enforcing parentheses on `expect(...).to change { ... }` often leads to poor readability and fights against native RuboCop layout rules (causing indentation loops or visual misalignment).

## Changes

This PR introduces the `AllowedMethods` configuration option to the cop.

  - **Logic:** Updated the cop to check if the method name is present in the `AllowedMethods` list. If so, it ignores the method even if it spans multiple lines and lacks parentheses.
  - **Config:** Added `AllowedMethods` to `config/default.yml` (defaulting to `[]`) to satisfy `InternalAffairs/UndefinedConfig`.
  - **Tests:** Added specs to verify that whitelisted methods do not register offenses.

## How to Configure

Users can now configure their `.rubocop.yml` to exempt specific methods:

```yaml
Vicenzo/Style/MultilineMethodCallParentheses:
  AllowedMethods:
    - to
    - not_to
    - to_not
```

## Example

With the configuration above, the following code is now **valid** (previously flagged as an offense):

```ruby
# Now allowed (No parentheses required on .to)
expect { action }.to change {
  model.attribute
}.from(1).to(2)
```

Regular method calls not in the list will still require parentheses:

```ruby
# Still flagged (Requires parentheses)
create_user :param,
            :other_param
```