### PR TITLE
Generates Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.3.0] - 2025-12-17
+
 - Add RuboCop::Cop::Vicenzo::Layout::MultilineMethodCallLineBreaks #12;
 - Add RuboCop::Cop::Vicenzo::Style::MultilineMethodCallParentheses #13;
 - Add `AllowedMethods` configuration to `Vicenzo/Style/MultilineMethodCallParentheses` to allow excluding specific methods (e.g., RSpec DSLs like `to` and `change`) from the rule #15;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vicenzo (0.2.0)
+    rubocop-vicenzo (0.3.0)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.2)
       rubocop-rspec (>= 3.5.0)

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,7 +3,7 @@ Vicenzo/Layout/MultilineMethodCallLineBreaks:
   Enabled: true
   Severity: convention
   IndentationWidth: 2
-  VersionAdded: '<<next>>'
+  VersionAdded: '0.3.0'
 
 Vicenzo/Rails/EnumInclusionOfValidation:
   Description: 'Check if the enum has the inclusion of validation defined.'
@@ -50,4 +50,4 @@ Vicenzo/Style/MultilineMethodCallParentheses:
   Description: 'Enforces parentheses for method calls with arguments that span multiple lines.'
   Enabled: true
   AllowedMethods: []
-  VersionAdded: '<<next>>'
+  VersionAdded: '0.3.0'

--- a/lib/rubocop/vicenzo/version.rb
+++ b/lib/rubocop/vicenzo/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vicenzo
-    VERSION = '0.2.0'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
## [0.3.0] - 2025-12-17

- Add RuboCop::Cop::Vicenzo::Layout::MultilineMethodCallLineBreaks #12;
- Add RuboCop::Cop::Vicenzo::Style::MultilineMethodCallParentheses #13;
- Add `AllowedMethods` configuration to `Vicenzo/Style/MultilineMethodCallParentheses` to allow excluding specific methods (e.g., RSpec DSLs like `to` and `change`) from the rule #15;
