### PR TITLE
Add RSpec cops against dynamic examples, iterative assertions, and conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Add RuboCop::Cop::Vicenzo::RSpec::DynamicExampleGeneration;
+- Add RuboCop::Cop::Vicenzo::RSpec::IterationInsideExample;
 
 ## [0.3.0] - 2025-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Add RuboCop::Cop::Vicenzo::RSpec::ConditionalInSpec;
 - Add RuboCop::Cop::Vicenzo::RSpec::DynamicExampleGeneration;
 - Add RuboCop::Cop::Vicenzo::RSpec::IterationInsideExample;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add RuboCop::Cop::Vicenzo::RSpec::DynamicExampleGeneration;
+
 ## [0.3.0] - 2025-12-17
 
 - Add RuboCop::Cop::Vicenzo::Layout::MultilineMethodCallLineBreaks #12;

--- a/config/default.yml
+++ b/config/default.yml
@@ -23,6 +23,12 @@ Vicenzo/RSpec/InconsistentSiblingStructure:
   Severity: warning
   VersionAdded: '0.2.0'
 
+Vicenzo/RSpec/IterationInsideExample:
+  Description: 'Do not call `expect` inside an iteration within an example.'
+  Enabled: true
+  Severity: warning
+  VersionAdded: '0.4.0'
+
 Vicenzo/RSpec/NestedContextImproperStart:
   Description: 'Check if the nested context does not start as a root one.'
   Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,12 @@ Vicenzo/Rails/EnumInclusionOfValidation:
   Severity: convention
   VersionAdded: '0.1.0'
 
+Vicenzo/RSpec/DynamicExampleGeneration:
+  Description: 'Do not use iteration to dynamically generate example groups or examples.'
+  Enabled: true
+  Severity: warning
+  VersionAdded: '0.4.0'
+
 Vicenzo/RSpec/InconsistentSiblingStructure:
   Description: 'Enforces strict structural consistency (e.g. prevents mixing describe with context or examples with groups).'
   Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,6 +11,17 @@ Vicenzo/Rails/EnumInclusionOfValidation:
   Severity: convention
   VersionAdded: '0.1.0'
 
+Vicenzo/RSpec/ConditionalInSpec:
+  Description: 'Do not use conditional logic in specs. Extract each branch into an explicit context instead.'
+  Enabled: true
+  Severity: warning
+  Include:
+    - '**/spec/**/*_spec.rb'
+  Exclude:
+    - '**/spec/support/**/*'
+    - '**/spec/factories/**/*'
+  VersionAdded: '0.4.0'
+
 Vicenzo/RSpec/DynamicExampleGeneration:
   Description: 'Do not use iteration to dynamically generate example groups or examples.'
   Enabled: true

--- a/lib/rubocop/cop/vicenzo/rspec/conditional_in_spec.rb
+++ b/lib/rubocop/cop/vicenzo/rspec/conditional_in_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Vicenzo
+      module RSpec
+        # Do not use conditional logic in spec files.
+        #
+        # Any `if`, `unless`, or ternary expression in a spec represents a hidden
+        # context. Each branch should be an explicit `context` block so that the
+        # conditions and expectations are always clear and unconditional.
+        #
+        # @example
+        #   # bad — hidden context inside an example
+        #
+        #   it 'grants or denies access' do
+        #     if user.admin?
+        #       expect(result).to eq(:granted)
+        #     else
+        #       expect(result).to eq(:denied)
+        #     end
+        #   end
+        #
+        #   # bad — hidden context inside a let
+        #
+        #   let(:user) { admin? ? create(:admin) : create(:client) }
+        #
+        #   # bad — hidden context inside a before hook
+        #
+        #   before { setup_thing if feature_enabled? }
+        #
+        #   # bad — hidden context at the example group level using unless
+        #
+        #   unless legacy_mode?
+        #     it 'uses the new behaviour' do
+        #       ...
+        #     end
+        #   end
+        #
+        #   # good
+        #
+        #   context 'when user is admin' do
+        #     let(:user) { create(:admin) }
+        #
+        #     it 'grants access' do
+        #       expect(result).to eq(:granted)
+        #     end
+        #   end
+        #
+        #   context 'when user is not admin' do
+        #     let(:user) { create(:client) }
+        #
+        #     it 'denies access' do
+        #       expect(result).to eq(:denied)
+        #     end
+        #   end
+        class ConditionalInSpec < RuboCop::Cop::RSpec::Base
+          MSG = 'Do not use conditional logic in specs. ' \
+                'Extract each branch into an explicit context instead.'
+
+          # Both `if` and `unless` are represented as `if` nodes in the AST,
+          # so this single hook covers all conditional forms: `if`, `unless`,
+          # modifier `if`/`unless`, and ternary `?:`.
+          def on_if(node)
+            offense_location = node.ternary? ? node : node.loc.keyword
+            add_offense(offense_location)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/vicenzo/rspec/dynamic_example_generation.rb
+++ b/lib/rubocop/cop/vicenzo/rspec/dynamic_example_generation.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Vicenzo
+      module RSpec
+        # Do not use iteration to dynamically generate example groups or examples.
+        #
+        # Dynamic generation makes tests hard to find, hard to read, and creates
+        # pressure to add conditional logic (e.g. `if variable == :x`) when not
+        # all iterations share the same conditions. Write explicit, static contexts
+        # instead — one context per case.
+        #
+        # @example
+        #   # bad
+        #
+        #   [:admin, :driver].each do |role|
+        #     context "when role is #{role}" do
+        #       it 'does something' do
+        #         ...
+        #       end
+        #     end
+        #   end
+        #
+        #   # good
+        #
+        #   context 'when role is admin' do
+        #     let(:role) { :admin }
+        #
+        #     it 'does something' do
+        #       ...
+        #     end
+        #   end
+        #
+        #   context 'when role is driver' do
+        #     let(:role) { :driver }
+        #
+        #     it 'does something' do
+        #       ...
+        #     end
+        #   end
+        class DynamicExampleGeneration < RuboCop::Cop::RSpec::Base
+          MSG = 'Do not use iteration to dynamically generate example groups or examples. ' \
+                'Write explicit, static contexts instead.'
+
+          ENUMERATION_METHODS = %i[each each_with_index each_with_object map flat_map].freeze
+
+          EXAMPLE_GROUP_DSL = %i[
+            context describe feature experiment
+            it specify example scenario focus
+            let let! subject subject! before after around
+            shared_examples shared_context shared_examples_for
+          ].freeze
+
+          # @!method enumeration_block?(node)
+          def_node_matcher :enumeration_block?, <<~PATTERN
+            (block
+              (send _ {#{ENUMERATION_METHODS.map(&:inspect).join(' ')}} ...)
+              ...)
+          PATTERN
+
+          # @!method example_group_dsl_call?(node)
+          def_node_matcher :example_group_dsl_call?, <<~PATTERN
+            (block (send nil? {#{EXAMPLE_GROUP_DSL.map(&:inspect).join(' ')}} ...) ...)
+          PATTERN
+
+          def on_block(node)
+            return unless enumeration_block?(node)
+            return unless contains_example_group_dsl?(node)
+
+            add_offense(node.send_node)
+          end
+
+          alias on_numblock on_block
+
+          private
+
+          def contains_example_group_dsl?(node)
+            node.body&.each_node(:block) do |child|
+              return true if example_group_dsl_call?(child)
+            end
+
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/vicenzo/rspec/iteration_inside_example.rb
+++ b/lib/rubocop/cop/vicenzo/rspec/iteration_inside_example.rb
@@ -75,7 +75,7 @@ module RuboCop
           def contains_expectation?(node)
             return false unless node
 
-            node.each_node(:send).any? { |send_node| send_node.method_name == :expect }
+            node.each_node(:send).any? { |send_node| send_node.method?(:expect) }
           end
         end
       end

--- a/lib/rubocop/cop/vicenzo/rspec/iteration_inside_example.rb
+++ b/lib/rubocop/cop/vicenzo/rspec/iteration_inside_example.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Vicenzo
+      module RSpec
+        # Do not use `expect` inside an iteration within an example.
+        #
+        # Placing `expect` calls inside an iteration block (e.g. `each`) makes
+        # tests implicit and hard to debug: when the assertion fails it is unclear
+        # which element caused the failure, and not all elements may represent the
+        # same condition. Using iteration to build or transform data before calling
+        # `expect` is fine; the problem is calling `expect` inside the iteration.
+        # Write explicit assertions for each relevant case instead.
+        #
+        # @example
+        #   # bad — expect is called inside the iteration
+        #
+        #   it 'returns vehicle costs general values' do
+        #     response_body[:vehicle_costs].first.each do |attribute, value|
+        #       expect(value).to eq(vehicle_cost.send(attribute).to_s)
+        #     end
+        #   end
+        #
+        #   # good — iteration builds data, expect is called once outside
+        #
+        #   it 'returns the expected column names' do
+        #     columns = VehicleCost.column_names.map { |column| column.gsub('_centavos', '') }
+        #     expect(response_body[:vehicle_costs].first.keys).to match_array(columns.map(&:to_sym))
+        #   end
+        #
+        #   # good — each attribute has an explicit example
+        #
+        #   it 'returns the correct name' do
+        #     expect(response_body[:vehicle_costs].first[:name]).to eq(vehicle_cost.name)
+        #   end
+        #
+        #   it 'returns the correct value' do
+        #     expect(response_body[:vehicle_costs].first[:value]).to eq(vehicle_cost.value.to_s)
+        #   end
+        class IterationInsideExample < RuboCop::Cop::RSpec::Base
+          MSG = 'Do not call `expect` inside an iteration. ' \
+                'Write explicit assertions instead.'
+
+          ENUMERATION_METHODS = %i[each each_with_index each_with_object].freeze
+
+          # @!method enumeration_block?(node)
+          def_node_matcher :enumeration_block?, <<~PATTERN
+            (block
+              (send _ {#{ENUMERATION_METHODS.map(&:inspect).join(' ')}} ...)
+              ...)
+          PATTERN
+
+          def on_block(node)
+            return unless example?(node)
+
+            find_iterations_with_assertions(node.body)
+          end
+
+          alias on_numblock on_block
+
+          private
+
+          def find_iterations_with_assertions(body)
+            return unless body
+
+            body.each_node(:block) do |iteration|
+              next unless enumeration_block?(iteration)
+              next unless contains_expectation?(iteration.body)
+
+              add_offense(iteration.send_node)
+            end
+          end
+
+          def contains_expectation?(node)
+            return false unless node
+
+            node.each_node(:send).any? { |send_node| send_node.method_name == :expect }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/vicenzo_cops.rb
+++ b/lib/rubocop/cop/vicenzo_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'vicenzo/rspec/conditional_in_spec'
 require_relative 'vicenzo/rspec/dynamic_example_generation'
 require_relative 'vicenzo/rspec/inconsistent_sibling_structure'
 require_relative 'vicenzo/rspec/iteration_inside_example'

--- a/lib/rubocop/cop/vicenzo_cops.rb
+++ b/lib/rubocop/cop/vicenzo_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'vicenzo/rspec/dynamic_example_generation'
 require_relative 'vicenzo/rspec/inconsistent_sibling_structure'
 require_relative 'vicenzo/rspec/nested_context_improper_start'
 require_relative 'vicenzo/rspec/nested_let_redefinition'

--- a/lib/rubocop/cop/vicenzo_cops.rb
+++ b/lib/rubocop/cop/vicenzo_cops.rb
@@ -2,6 +2,7 @@
 
 require_relative 'vicenzo/rspec/dynamic_example_generation'
 require_relative 'vicenzo/rspec/inconsistent_sibling_structure'
+require_relative 'vicenzo/rspec/iteration_inside_example'
 require_relative 'vicenzo/rspec/nested_context_improper_start'
 require_relative 'vicenzo/rspec/nested_let_redefinition'
 require_relative 'vicenzo/rspec/nested_subject_redefinition'

--- a/spec/rubocop/cop/vicenzo/rspec/conditional_in_spec_spec.rb
+++ b/spec/rubocop/cop/vicenzo/rspec/conditional_in_spec_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Vicenzo::RSpec::ConditionalInSpec, :rspec_config do
+  context 'when if is used inside an it block' do
+    it 'registers an offense on the if keyword' do
+      expect_offense(<<~RUBY)
+        it 'grants or denies access' do
+          if user.admin?
+          ^^ Do not use conditional logic in specs. Extract each branch into an explicit context instead.
+            expect(result).to eq(:granted)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when unless is used inside an it block' do
+    it 'registers an offense on the unless keyword' do
+      expect_offense(<<~RUBY)
+        it 'denies access for non-admins' do
+          unless user.admin?
+          ^^^^^^ Do not use conditional logic in specs. Extract each branch into an explicit context instead.
+            expect(result).to eq(:denied)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when a modifier if is used inside a before hook' do
+    it 'registers an offense on the if keyword' do
+      expect_offense(<<~RUBY)
+        before { setup_thing if feature_enabled? }
+                             ^^ Do not use conditional logic in specs. Extract each branch into an explicit context instead.
+      RUBY
+    end
+  end
+
+  context 'when a modifier unless is used inside a before hook' do
+    it 'registers an offense on the unless keyword' do
+      expect_offense(<<~RUBY)
+        before { setup_thing unless feature_disabled? }
+                             ^^^^^^ Do not use conditional logic in specs. Extract each branch into an explicit context instead.
+      RUBY
+    end
+  end
+
+  context 'when a ternary is used inside a let' do
+    it 'registers an offense on the ternary expression' do
+      expect_offense(<<~RUBY)
+        let(:user) { admin? ? create(:admin) : create(:client) }
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use conditional logic in specs. Extract each branch into an explicit context instead.
+      RUBY
+    end
+  end
+
+  context 'when unless is used at the example group level' do
+    it 'registers an offense on the unless keyword' do
+      expect_offense(<<~RUBY)
+        unless legacy_mode?
+        ^^^^^^ Do not use conditional logic in specs. Extract each branch into an explicit context instead.
+          it 'uses the new behaviour' do
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when if is used at the example group level' do
+    it 'registers an offense on the if keyword' do
+      expect_offense(<<~RUBY)
+        if created_by == :whatsapp_driver
+        ^^ Do not use conditional logic in specs. Extract each branch into an explicit context instead.
+          it 'has exclusive whatsapp driver behaviour' do
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when if is used inside a subject' do
+    it 'registers an offense on the if keyword' do
+      expect_offense(<<~RUBY)
+        subject(:result) do
+          if user.admin?
+          ^^ Do not use conditional logic in specs. Extract each branch into an explicit context instead.
+            :granted
+          else
+            :denied
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/vicenzo/rspec/dynamic_example_generation_spec.rb
+++ b/spec/rubocop/cop/vicenzo/rspec/dynamic_example_generation_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Vicenzo::RSpec::DynamicExampleGeneration, :rspec_config do
+  context 'when iteration generates context blocks' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        [:admin, :driver].each do |role|
+        ^^^^^^^^^^^^^^^^^^^^^^ Do not use iteration to dynamically generate example groups or examples. Write explicit, static contexts instead.
+          context "when role is \#{role}" do
+            it 'does something' do
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration generates it blocks directly' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        [:active, :inactive].each do |status|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use iteration to dynamically generate example groups or examples. Write explicit, static contexts instead.
+          it "works for \#{status}" do
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration generates let definitions' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        [:foo, :bar].each do |name|
+        ^^^^^^^^^^^^^^^^^ Do not use iteration to dynamically generate example groups or examples. Write explicit, static contexts instead.
+          let(name) { create(:thing) }
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration generates before hooks' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        [:a, :b].each do |trait|
+        ^^^^^^^^^^^^^ Do not use iteration to dynamically generate example groups or examples. Write explicit, static contexts instead.
+          before { setup(trait) }
+        end
+      RUBY
+    end
+  end
+
+  context 'when each_with_index is used to generate contexts' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        [:admin, :driver].each_with_index do |role, index|
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use iteration to dynamically generate example groups or examples. Write explicit, static contexts instead.
+          context "case \#{index}" do
+            it 'does something' do
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when map is used to generate contexts' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        [:admin, :driver].map do |role|
+        ^^^^^^^^^^^^^^^^^^^^^ Do not use iteration to dynamically generate example groups or examples. Write explicit, static contexts instead.
+          context "when role is \#{role}" do
+            it 'does something' do
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration is used inside a regular method (not in a spec context)' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def setup_roles
+          [:admin, :driver].each do |role|
+            create(:user, role: role)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration does not contain any example group DSL' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        it 'processes all roles' do
+          [:admin, :driver].each do |role|
+            expect(role).to be_a(Symbol)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration is used inside a before hook to set up data' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        before do
+          [:admin, :driver].each do |role|
+            create(:user, role: role)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration is used inside a let to build a collection' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        let(:users) do
+          [:admin, :driver].map do |role|
+            create(:user, role: role)
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/vicenzo/rspec/iteration_inside_example_spec.rb
+++ b/spec/rubocop/cop/vicenzo/rspec/iteration_inside_example_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Vicenzo::RSpec::IterationInsideExample, :rspec_config do
+  context 'when expect is called inside an each block within an example' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        it 'returns all attributes' do
+          response.first.each do |attribute, value|
+          ^^^^^^^^^^^^^^^^^^^ Do not call `expect` inside an iteration. Write explicit assertions instead.
+            expect(value).to eq(record.send(attribute).to_s)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when expect is called inside an each_with_index block within an example' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        it 'returns items in order' do
+          results.each_with_index do |result, position|
+          ^^^^^^^^^^^^^^^^^^^^^^^ Do not call `expect` inside an iteration. Write explicit assertions instead.
+            expect(result[:position]).to eq(position)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when expect is called inside an each_with_object block within an example' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        it 'processes each item' do
+          items.each_with_object({}) do |item, accumulator|
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not call `expect` inside an iteration. Write explicit assertions instead.
+            expect(item).to be_valid
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration is used to build data and expect is called outside' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        it 'returns the expected column names' do
+          columns = VehicleCost.column_names.map { |column| column.gsub('_centavos', '') }
+          expect(response.first.keys).to match_array(columns.map(&:to_sym))
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration is used inside a before hook' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        before do
+          roles.each do |role|
+            expect(role).to be_valid
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration is used at example group level (outside an example)' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        [:admin, :driver].each do |role|
+          context "when role is \#{role}" do
+            it 'does something' do
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when iteration inside an example does not contain expect' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        it 'processes roles' do
+          roles.each do |role|
+            setup(role)
+          end
+
+          expect(result).to be_success
+        end
+      RUBY
+    end
+  end
+
+  context 'when specify is used instead of it' do
+    it 'registers an offense on the iteration call' do
+      expect_offense(<<~RUBY)
+        specify 'returns all attributes' do
+          response.first.each do |attribute, value|
+          ^^^^^^^^^^^^^^^^^^^ Do not call `expect` inside an iteration. Write explicit assertions instead.
+            expect(value).to eq(record.send(attribute).to_s)
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR introduces three new RSpec cops focused on enforcing explicit, static test structure. All three target patterns that make specs harder to read, harder to debug, and more likely to accumulate hidden complexity over time.

---

### `Vicenzo/RSpec/DynamicExampleGeneration`

Flags iteration methods (`each`, `map`, `flat_map`, etc.) used at the example group level to generate `context`, `describe`, `it`, `let`, `before`, or other RSpec DSL blocks dynamically.

Dynamic generation makes individual tests impossible to find by name, produces failure messages that are hard to trace back to intent, and — most critically — creates pressure to introduce conditional logic inside the loop when not all iterations share the same conditions.

```ruby
# bad
[:admin_backoffice, :app_driver, :whatsapp_driver].each do |created_by|
  context "and line vehicle schedule is created by #{created_by}" do
    it 'returns displacement status' do ...
  end
end

# good — one explicit context per case
context 'and line vehicle schedule is created by admin backoffice' do
  it 'returns displacement status' do ...
end
```

---

### `Vicenzo/RSpec/IterationInsideExample`

Flags `each`, `each_with_index`, and `each_with_object` calls inside an `it` or `specify` block when `expect` is called within the iteration body.

Iterating to build or transform data before an assertion is fine. The problem is delegating the assertion itself to the loop: when it fails, it is unclear which element caused the failure, and not all elements necessarily represent the same condition. Using iteration to prepare data and calling `expect` once outside remains allowed.

```ruby
# bad
it 'returns vehicle costs general values' do
  response_body[:vehicle_costs].first.each do |attribute, value|
    expect(value).to eq(vehicle_cost.send(attribute).to_s)
  end
end

# good — iteration prepares data, single assertion outside
it 'returns the expected column names' do
  columns = VehicleCost.column_names.map { |column| column.gsub('_centavos', '') }
  expect(response_body.first.keys).to match_array(columns.map(&:to_sym))
end
```

---

### `Vicenzo/RSpec/ConditionalInSpec`

Flags any `if`, `unless`, modifier `if`/`unless`, or ternary expression anywhere in a spec file.

Every conditional in a spec is a hidden context. Each branch represents a distinct scenario that deserves its own explicit `context` block with clear setup and unconditional assertions. Because `unless` is internally represented as an `if` node in Ruby's AST, a single hook covers all conditional forms — swapping `if` for `unless` is not an escape.

```ruby
# bad — hidden contexts in a let and a before
let(:user) { admin? ? create(:admin) : create(:client) }
before { setup_thing if feature_enabled? }

# good — each scenario is explicit
context 'when user is admin' do
  let(:user) { create(:admin) }
  before { setup_thing }
end

context 'when user is not admin' do
  let(:user) { create(:client) }
end
```