### PR TITLE
Fix start page on antora playbook

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,6 +1,7 @@
 site:
   title: RuboCop Vicenzo
   url: https://bvicenzo.github.io/rubocop-vicenzo
+  start_page: rubocop-vicenzo::index.adoc
 
 content:
   sources:


### PR DESCRIPTION
This was causing a page not found on root URL

<img width="1565" height="473" alt="image" src="https://github.com/user-attachments/assets/df69a554-9671-4070-bdf0-cd43d5b377ad" />
