### PR TITLE
Generate 0.5.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-- Add RuboCop::Cop::Vicenzo::Style::JsonParseSymbolizeNames;
+## [0.5.0] - 2026-06-29
+
+- Add RuboCop::Cop::Vicenzo::Style::JsonParseSymbolizeNames #23;
 
 ## [0.4.0] - 2026-03-28
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-vicenzo (0.4.0)
+    rubocop-vicenzo (0.5.0)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.2)
       rubocop-rspec (>= 3.5.0)

--- a/config/default.yml
+++ b/config/default.yml
@@ -73,7 +73,7 @@ Vicenzo/Style/JsonParseSymbolizeNames:
   Description: 'Enforces passing `symbolize_names: true` to `JSON.parse` so keys are symbols.'
   Enabled: true
   Severity: convention
-  VersionAdded: '<<next>>'
+  VersionAdded: '0.5.0'
 
 Vicenzo/Style/MultilineMethodCallParentheses:
   Description: 'Enforces parentheses for method calls with arguments that span multiple lines.'

--- a/lib/rubocop/vicenzo/version.rb
+++ b/lib/rubocop/vicenzo/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Vicenzo
-    VERSION = '0.4.0'
+    VERSION = '0.5.0'
   end
 end


### PR DESCRIPTION
## Summary

Release 0.5.0. Bumps the version, locks it in `Gemfile.lock`, and moves the
`[Unreleased]` changelog items under the new `0.5.0` header.

## Included since 0.4.0

- Add `Vicenzo/Style/JsonParseSymbolizeNames` — enforces `symbolize_names: true`
  on `JSON.parse` so keys are symbols (#23).

## Changes

- `lib/rubocop/vicenzo/version.rb`: `0.4.0` → `0.5.0`
- `config/default.yml`: `VersionAdded` of the new cop resolved from `<<next>>` to `0.5.0`
- `CHANGELOG.md`: items moved to `## [0.5.0] - 2026-06-29`
- `Gemfile.lock`: PATH spec updated to `0.5.0`